### PR TITLE
fixed too early config call, added test to help to run a game, change…

### DIFF
--- a/config.py
+++ b/config.py
@@ -2485,7 +2485,7 @@ class Config(object):
             ####################
 
         self.path_to_json_grammar_specification = (
-            '/Users/jamesryan/Desktop/Projects/Personal/anytown/content/talktown.json'
+            './talktown.json'
         )
         # Frame definitions
         self.conversational_frames = {

--- a/game.py
+++ b/game.py
@@ -12,12 +12,12 @@ class Game(object):
     def __init__(self):
         """Initialize a Game object."""
         # Load the NLG module for this game instance
+        self.config = Config()
         self.productionist = Productionist(game=self)
         # This gets incremented each time a new person is born/generated,
         # which affords a persistent ID for each person
         self.current_person_id = 0
         self.current_place_id = 0
-        self.config = Config()
         self.year = self.config.date_worldgen_begins[0]
         self.true_year = self.config.date_worldgen_begins[0]  # True year never gets changed during retconning
         self.ordinal_date = datetime.date(*self.config.date_worldgen_begins).toordinal()  # Days since 01-01-0001

--- a/test.py
+++ b/test.py
@@ -1,0 +1,28 @@
+from game import Game
+
+game = Game()
+print game
+game.establish_setting()
+print 'settings established'
+#see what businesses are in the town with:
+print 'city companies'
+for c in game.city.companies:
+    print c
+
+print 'former companies'
+#explore some of the history of the town:
+for c in game.city.former_companies:
+    print c
+
+# list a random resident's social relations with everyone in the town:
+p = game.random_person
+print 'random person', p
+for r in game.city.residents:
+    print p.relation_to_me(r)
+
+# explore a characters mental models:
+p = game.random_person
+print p
+print 'random person mental models', p
+for person_home_or_business in p.mind.mental_models:
+    print p.mind.mental_models[person_home_or_business]


### PR DESCRIPTION
fixed too early config call, added test to help to run a game, changed talktown.json path to relative

The game.config is undefined here. See Game class declaration

```
class Game(object):
    """A gameplay instance."""
    def __init__(self):
        """Initialize a Game object."""
        # Load the NLG module for this game instance
        self.productionist = Productionist(game=self)
        # This gets incremented each time a new person is born/generated,
        # which affords a persistent ID for each person
        self.current_person_id = 0
        self.current_place_id = 0
        self.config = Config()
```

Also I think it's better to use relative paths, because config.py is under git control it's inconvenient to change it for every user.
